### PR TITLE
Correct timeout from 0.3m to 3m

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::sync::mpsc::channel;
 use std::thread;
 use std::time::Duration;
 
-const TIMEOUT: u64 = 3 * 60 * 100; //3 minutes
+const TIMEOUT: u64 = 3 * 60 * 1000; //3 minutes
 static mut DEBUG: bool = false;
 
 fn print_usage(program: &str, opts: Options) {


### PR DESCRIPTION
Zero is left out in the `TIMEOUT` constant, which results in timeout being 0.3 minutes, not 3, which is desired value, as suggested by the comment. This PR fixes that